### PR TITLE
Fix proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ENV DEBIAN_FRONTEND noninteractive
 # If needed, then only to build images. Images are usually fetched
 # from a registry and environment variables can be set during runime
 # (see README.md)
+# The no_proxy variable allows Bagbunker internal communication.
+ENV no_proxy 127.0.0.1
 #ENV http_proxy http://172.17.0.1:3128/
 #ENV https_proxy http://172.17.0.1:3128/
 


### PR DESCRIPTION
If the proxy is enabled, it breaks the MARV_SIGNAL_URL communication
because all http requests are forwarded to the proxy on the host that
cannot handle them. Setting no_proxy to 127.0.0.1 excludes the local
host from using a proxy, thereby fixing communications.

As far as I can tell, having the no_proxy setting on permanently does not cause any harm, so this PR leaves it uncommented.