### PR TITLE
Show fileset name in HTML title

### DIFF
--- a/src/bagbunker/bagbunker/frontend/app/pods/bagbunker/detail/route.js
+++ b/src/bagbunker/bagbunker/frontend/app/pods/bagbunker/detail/route.js
@@ -34,6 +34,7 @@ export default Ember.Route.extend(ResetScroll, {
             contentType: 'application/vnd.api+json'
         }).then(r => {
             return this.store.findRecord('fileset', r.data.id).then(fileset => {
+                document.title = 'BB: ' + r.data.name;
                 r.data.fileset = fileset;
                 return r.data;
             });

--- a/src/bagbunker/bagbunker/frontend/app/pods/bagbunker/index/route.js
+++ b/src/bagbunker/bagbunker/frontend/app/pods/bagbunker/index/route.js
@@ -40,6 +40,8 @@ export default Ember.Route.extend(ResetScroll, {
             };
         }
 
+        document.title = 'Bagbunker';
+
         return {
             summary: await app.api('/marv/api/_fileset-summary', attrs),
             listing: await app.api('/marv/api/_fileset-listing', attrs)


### PR DESCRIPTION
This PR shows "BB: fileset name" instead of "Bagbunker" as the page title when viewing the details of a fileset. This is handy when opening a few filesets as tabs, because you can now see which filesets you opened.

I don't know if this is the right place to implement, but it seems to work and is quite a handy feature.

Relates to #28.
