### PR TITLE
Use timezone info in date formatter

### DIFF
--- a/src/marv/marv/frontend/app/helpers/formatter/date.js
+++ b/src/marv/marv/frontend/app/helpers/formatter/date.js
@@ -24,9 +24,9 @@ import Ember from 'ember';
 import moment from 'moment';
 
 export function helper([date], kwargs) {
-    const format = kwargs.format || 'YYYY-MM-DD hh:mm:ss';
+    const format = kwargs.format || 'YYYY-MM-DD HH:mm:ss';
     if (date) {
-        return moment(date).format(format);
+        return moment.parseZone(date).format(format);
     } else {
         return '';
     }


### PR DESCRIPTION
Fixes #107.
The rosbag timestamps are saved in the local timezone, so using
parseZone() shows the time correctly.
Additionally switched to 24h representation.

There remains a problem with the comment time. Comment timestamps are taken in UTC and the relative time is also computed using UTC, therefore everything is correct. On mouseover, the raw timestamp in UTC is shown, with no indication that it is in UTC. This either requires a special 'print-localtime' formatter or the timestamps should be recorded in the local timezone (as for bagfiles).