### PR TITLE
Fix error message when scanner cannot read file

### DIFF
--- a/src/marv/marv/scanner.py
+++ b/src/marv/marv/scanner.py
@@ -68,6 +68,10 @@ class EmptyFile(BrokenFileset):
     pass
 
 
+class UnreadleFile(BrokenFileset):
+    pass
+
+
 def detect_filesets(basedir, scanners):
     """Walk basedir using scanners to detect filesets, return filesetinfos"""
     logger = getLogger(__name__)
@@ -86,6 +90,9 @@ def detect_filesets(basedir, scanners):
 def make_file(fileinfo):
     """Make File model from FileInfo"""
     path = os.path.join(fileinfo.dirpath, fileinfo.name)
+
+    if not os.access(path, os.R_OK):
+        raise UnreadleFile(fileinfo.dirpath, fileinfo.name)
 
     md5file = '{}.md5'.format(path)
     try:

--- a/src/marv/marv/storage.py
+++ b/src/marv/marv/storage.py
@@ -141,6 +141,10 @@ class Storage(object):
 
                     # New fileset?
                     if active is None:
+                        if not self.verify_readable(found):
+                            logger.warn('one or more files of this fileset are not readable, check permissions %r', found)
+                            continue
+
                         if not self.verify_md5(found):
                             logger.warn('skipped MD5 mismatch %r', found)
                             continue
@@ -195,5 +199,11 @@ class Storage(object):
                                cwd=fileset.dirpath,
                                stderr=subprocess.PIPE,
                                stdout=subprocess.PIPE) != 0:
+                return False
+        return True
+
+    def verify_readable(self, fileset):
+        for file in fileset.files:
+            if not os.access(file.path, os.R_OK):
                 return False
         return True


### PR DESCRIPTION
Files with incorrect permissions (not readable by scanner) failed in the MD5 check, generating an error message that the MD5 sum is incorrect. This PR should fix this and let the scanner now return an error indicating that the file is not readable.